### PR TITLE
Add an audioconvert and audioresample step between decodebin and lamemp3enc.

### DIFF
--- a/dmp-client/dmp_sender.hpp
+++ b/dmp-client/dmp_sender.hpp
@@ -9,6 +9,8 @@ class DmpSender : public GStreamerBase
 {	
 	std::unique_ptr<GstElement, GStreamerEmptyDeleter> source;
 	std::unique_ptr<GstElement, GStreamerEmptyDeleter> decoder;
+	std::unique_ptr<GstElement, GStreamerEmptyDeleter> converter;
+	std::unique_ptr<GstElement, GStreamerEmptyDeleter> resampler;
 	std::unique_ptr<GstElement, GStreamerEmptyDeleter> encoder;
 //	std::unique_ptr<GstElement, GStreamerEmptyDeleter> rtppay;
 	std::unique_ptr<GstElement, GStreamerEmptyDeleter> sink;


### PR DESCRIPTION
Fixes an issue where the two elements could not be connected on my machine on some tracks.
