### PR TITLE
Don't crash server when processing of a client message failed.

### DIFF
--- a/dmp-server/dmp_server.cpp
+++ b/dmp-server/dmp_server.cpp
@@ -56,8 +56,8 @@ void DmpServer::add_connection(dmp::Connection&& c)
 		{
 			try {
 				connections[name_res.name]->run();
-			} catch(std::runtime_error e) {
-				std::cerr << "Endpoint unexpectedly disconnected with message: " << e.what() << std::endl;
+			} catch(std::exception &e) {
+				std::cerr << "Endpoint unexpectedly raised exception: " << e.what() << std::endl;
 			}
 			connections.erase(name_res.name);
 		}


### PR DESCRIPTION
Instead, close connection and print the error to stderr.
